### PR TITLE
Update Unbox implementations to use latest APIs

### DIFF
--- a/JSONShootout.xcodeproj/project.pbxproj
+++ b/JSONShootout.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 					CC5A1A111CEADE59007238F3 = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0800;
+						TestTargetID = CC5A19FD1CEADE59007238F3;
 					};
 					CC97869D1CEBABE7005A5DEA = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -556,6 +557,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.swift-bit.JSONShootoutTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JSONShootout.app/JSONShootout";
 			};
 			name = Debug;
 		};
@@ -567,6 +569,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.swift-bit.JSONShootoutTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JSONShootout.app/JSONShootout";
 			};
 			name = Release;
 		};

--- a/JSONShootoutTests/Unbox_Tests.swift
+++ b/JSONShootoutTests/Unbox_Tests.swift
@@ -17,10 +17,7 @@ class Unbox_Tests: XCTestCase {
         let dict = try! JSONSerialization.jsonObject(with: self.data, options: [])
         
         self.measure {
-            let programs:[Program] = try! Unboxer.performCustomUnboxing(dictionary: dict as! UnboxableDictionary) { unboxer in
-                let programs:[Program] = try! unboxer.unbox(keyPath:"ProgramList.Programs")
-                return programs
-            }
+            let programs:[Program] = try! unbox(dictionary: dict as! UnboxableDictionary, atKeyPath: "ProgramList.Programs")
             XCTAssert(programs.count > 1000)
         }
     }

--- a/ModelObjects/Program+Unbox.swift
+++ b/ModelObjects/Program+Unbox.swift
@@ -14,8 +14,8 @@ extension Program: Unboxable {
         description = unboxer.unbox(key:"Description")
         subtitle = unboxer.unbox(key:"SubTitle")
         recording = try unboxer.unbox(key:"Recording")
-        season = (unboxer.unbox(key:"Season") as String?).flatMap({Int($0)})
-        episode = (unboxer.unbox(key:"Episode") as String?).flatMap({Int($0)})
+        season = unboxer.unbox(key:"Season")
+        episode = unboxer.unbox(key:"Episode")
     }
 }
 

--- a/ModelObjects/Recording.swift
+++ b/ModelObjects/Recording.swift
@@ -14,11 +14,6 @@ public struct Recording {
         case Recorded = "-3"
         case Recording = "-2"
         case Unknown
-       
-        // compiler segfaults if we move this to an extension
-        static func unboxFallbackValue() -> Status {
-            return .Unknown
-        }
     }
     
     enum RecGroup: String, UnboxableEnum {
@@ -26,11 +21,6 @@ public struct Recording {
         case Default = "Default"
         case LiveTV = "LiveTV"
         case Unknown
-        
-        // compiler segfaults if we move this to an extension
-        static func unboxFallbackValue() -> RecGroup {
-            return .Unknown
-        }
     }
     
     

--- a/README.md
+++ b/README.md
@@ -117,35 +117,33 @@ let programs:[Program] = try! mapper.from("ProgramList.Programs")
 
 ```swift
 extension Recording: Unboxable {
-    public init(unboxer: Unboxer) {
+    public init(unboxer: Unboxer) throws {
         startTs = unboxer.unbox(key: "StartTs", formatter:NSDate.ISO8601SecondFormatter)
         endTs = unboxer.unbox(key: "EndTs", formatter:NSDate.ISO8601SecondFormatter)
-        startTsStr = unboxer.unbox(key: "StartTs")
-        recordId = unboxer.unbox(key: "RecordId")
+        startTsStr = try unboxer.unbox(key: "StartTs")
+        recordId = try unboxer.unbox(key: "RecordId")
         status = unboxer.unbox(key: "Status") ?? .Unknown
-        recGroup = (unboxer.unbox(key: "RecGroup")) ?? .Unknown
+        recGroup = unboxer.unbox(key: "RecGroup") ?? .Unknown
     }
 }
 
 extension Program: Unboxable {
-    public init(unboxer: Unboxer) {
-        title = unboxer.unbox(key: "Title")
-        chanId = unboxer.unbox(key: "Channel.ChanId", isKeyPath: true)
-        startTime = unboxer.unbox(key: "StartTime", formatter:NSDate.ISO8601SecondFormatter)
-        endTime = unboxer.unbox(key: "EndTime", formatter:NSDate.ISO8601SecondFormatter)
+    public init(unboxer: Unboxer) throws {
+        title = try unboxer.unbox(key: "Title")
+        chanId = try unboxer.unbox(keyPath: "Channel.ChanId")
+        startTime = try unboxer.unbox(key: "StartTime", formatter:NSDate.ISO8601SecondFormatter)
+        endTime = try unboxer.unbox(key: "EndTime", formatter:NSDate.ISO8601SecondFormatter)
         description = unboxer.unbox(key: "Description")
         subtitle = unboxer.unbox(key: "SubTitle")
-        recording = unboxer.unbox(key: "Recording")
-        season = (unboxer.unbox(key: "Season") as String?).flatMap({Int($0)})
-        episode = (unboxer.unbox(key: "Episode") as String?).flatMap({Int($0)})
+        recording = try unboxer.unbox(key: "Recording")
+        season = unboxer.unbox(key: "Season")
+        episode = unboxer.unbox(key: "Episode")
     }
 }
 
 // Extract an array of Programs
-let programs:[Program] = try! performCustomUnboxing(data: data) { unboxer in
-    let programs:[Program] = unboxer.unbox(key: "ProgramList.Programs", isKeyPath:true)
-    return programs
-}
+let dict = try! NSJSONSerialization.JSONObjectWithData(data, options: []) as! UnboxableDictionary
+let programs:[Program] = try! unbox(dictionary: dict, atKeyPath: "ProgramList.Programs")
 ```
 ##Analysis
 You can immediately see the similarities between the three projects. I won't get into the details of how they work here. You can read more about each project, or read Jason Larson's 


### PR DESCRIPTION
Hi @bwhiteley!

First of all, thanks for setting up this project - doing a side-by-side comparison of libraries is really useful for people when they want to pick which one to use 👍

I took the liberty of updating the Unbox implementations to use the latest APIs. To be able to run the tests, I also had to set the host application for the tests, otherwise I'd get a dynamic library error that the Swift runtime wasn't loaded.

Finally (thanks to this project actually!) I spent some time yesterday optimizing Unbox and released a new version - 2.2. With 2.2, Unbox is 50% faster and now clocks in at the ~800 ms range when the tests in this project are performed. Would you mind updating the graph to show these new results? Would be awesome 😃 I still have some catching up to do with Marshal it terms of speed, but we'll get there 😉

Here's an updated graph I put together:

<img width="602" alt="performance" src="https://cloud.githubusercontent.com/assets/2466701/19666832/2e8684d8-9a4d-11e6-9e12-757c25e3b5e6.png">
